### PR TITLE
Add database storage option for transaction logging

### DIFF
--- a/core/src/main/java/cn/superiormc/ultimateshop/database/SQLDatabase.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/database/SQLDatabase.java
@@ -24,6 +24,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
@@ -104,6 +106,10 @@ public class SQLDatabase extends AbstractDatabase {
             if (!UltimateShop.freeVersion) {
                 stmt.execute(dialect.createRandomPlaceholderTable());
                 stmt.execute(dialect.createCustomPlaceholderTable());
+                stmt.execute(dialect.createTransactionLogTable());
+                for (String indexSql : dialect.createTransactionLogIndexes()) {
+                    stmt.execute(indexSql);
+                }
             }
         } catch (SQLException e) {
             e.printStackTrace();
@@ -474,5 +480,42 @@ public class SQLDatabase extends AbstractDatabase {
         }
 
         CacheManager.cacheManager.removeObjectCache(cache);
+    }
+
+    public void logTransaction(LocalDateTime createdAt,
+                               String playerUuid,
+                               String playerName,
+                               String shopId,
+                               String shopName,
+                               String itemId,
+                               String itemName,
+                               String action,
+                               int amount,
+                               double multiplier,
+                               String priceText,
+                               String message) {
+        if (dataSource == null || dialect == null) {
+            return;
+        }
+        DatabaseExecutor.getExecutor().execute(() -> {
+            try (Connection conn = dataSource.getConnection();
+                 PreparedStatement ps = conn.prepareStatement(dialect.insertTransactionLog())) {
+                ps.setTimestamp(1, Timestamp.valueOf(createdAt));
+                ps.setString(2, playerUuid);
+                ps.setString(3, playerName);
+                ps.setString(4, shopId);
+                ps.setString(5, shopName);
+                ps.setString(6, itemId);
+                ps.setString(7, itemName);
+                ps.setString(8, action);
+                ps.setInt(9, amount);
+                ps.setDouble(10, multiplier);
+                ps.setString(11, priceText);
+                ps.setString(12, message);
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        });
     }
 }

--- a/core/src/main/java/cn/superiormc/ultimateshop/database/SQLDatabase.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/database/SQLDatabase.java
@@ -492,8 +492,7 @@ public class SQLDatabase extends AbstractDatabase {
                                String action,
                                int amount,
                                double multiplier,
-                               String priceText,
-                               String message) {
+                               String priceText) {
         if (dataSource == null || dialect == null) {
             return;
         }
@@ -511,7 +510,6 @@ public class SQLDatabase extends AbstractDatabase {
                 ps.setInt(9, amount);
                 ps.setDouble(10, multiplier);
                 ps.setString(11, priceText);
-                ps.setString(12, message);
                 ps.executeUpdate();
             } catch (SQLException e) {
                 e.printStackTrace();

--- a/core/src/main/java/cn/superiormc/ultimateshop/database/sql/DatabaseDialect.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/database/sql/DatabaseDialect.java
@@ -49,6 +49,17 @@ public abstract class DatabaseDialect {
 
     public abstract String insertFavourite();
 
+    public abstract String createTransactionLogTable();
+
+    public abstract String insertTransactionLog();
+
+    public String[] createTransactionLogIndexes() {
+        return new String[] {
+                "CREATE INDEX IF NOT EXISTS idx_us_transactions_created_at ON ultimateshop_transactions (created_at)",
+                "CREATE INDEX IF NOT EXISTS idx_us_transactions_player_uuid ON ultimateshop_transactions (player_uuid)"
+        };
+    }
+
     /** 是否支持批量写入 */
     public boolean supportBatch() {
         return true;

--- a/core/src/main/java/cn/superiormc/ultimateshop/database/sql/H2Dialect.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/database/sql/H2Dialect.java
@@ -148,8 +148,7 @@ public class H2Dialect extends DatabaseDialect {
                 action VARCHAR(4) NOT NULL,
                 amount INT NOT NULL,
                 multiplier DOUBLE NOT NULL,
-                price_text CLOB,
-                message CLOB
+                price_text CLOB
             )
         """;
     }
@@ -159,8 +158,8 @@ public class H2Dialect extends DatabaseDialect {
         return """
             INSERT INTO ultimateshop_transactions
             (created_at, player_uuid, player_name, shop_id, shop_name, item_id, item_name,
-             action, amount, multiplier, price_text, message)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             action, amount, multiplier, price_text)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """;
     }
 

--- a/core/src/main/java/cn/superiormc/ultimateshop/database/sql/H2Dialect.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/database/sql/H2Dialect.java
@@ -134,6 +134,37 @@ public class H2Dialect extends DatabaseDialect {
     }
 
     @Override
+    public String createTransactionLogTable() {
+        return """
+            CREATE TABLE IF NOT EXISTS ultimateshop_transactions (
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                created_at TIMESTAMP NOT NULL,
+                player_uuid VARCHAR(36) NOT NULL,
+                player_name VARCHAR(32) NOT NULL,
+                shop_id VARCHAR(48) NOT NULL,
+                shop_name VARCHAR(128) NOT NULL,
+                item_id VARCHAR(48) NOT NULL,
+                item_name VARCHAR(256) NOT NULL,
+                action VARCHAR(4) NOT NULL,
+                amount INT NOT NULL,
+                multiplier DOUBLE NOT NULL,
+                price_text CLOB,
+                message CLOB
+            )
+        """;
+    }
+
+    @Override
+    public String insertTransactionLog() {
+        return """
+            INSERT INTO ultimateshop_transactions
+            (created_at, player_uuid, player_name, shop_id, shop_name, item_id, item_name,
+             action, amount, multiplier, price_text, message)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+    }
+
+    @Override
     public void needExtraDownload(String jdbcUrl) {
         loadDriver("h2",
                 "https://repo1.maven.org/maven2/com/h2database/h2/2.2.220/h2-2.2.220.jar",

--- a/core/src/main/java/cn/superiormc/ultimateshop/database/sql/MySQLDialect.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/database/sql/MySQLDialect.java
@@ -157,7 +157,6 @@ public class MySQLDialect extends DatabaseDialect {
                 amount INT NOT NULL,
                 multiplier DOUBLE NOT NULL,
                 price_text TEXT,
-                message TEXT,
                 INDEX idx_us_transactions_created_at (created_at),
                 INDEX idx_us_transactions_player_uuid (player_uuid)
             )
@@ -169,8 +168,8 @@ public class MySQLDialect extends DatabaseDialect {
         return """
             INSERT INTO ultimateshop_transactions
             (created_at, player_uuid, player_name, shop_id, shop_name, item_id, item_name,
-             action, amount, multiplier, price_text, message)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             action, amount, multiplier, price_text)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """;
     }
 

--- a/core/src/main/java/cn/superiormc/ultimateshop/database/sql/MySQLDialect.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/database/sql/MySQLDialect.java
@@ -142,6 +142,44 @@ public class MySQLDialect extends DatabaseDialect {
     }
 
     @Override
+    public String createTransactionLogTable() {
+        return """
+            CREATE TABLE IF NOT EXISTS ultimateshop_transactions (
+                id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                created_at DATETIME NOT NULL,
+                player_uuid VARCHAR(36) NOT NULL,
+                player_name VARCHAR(32) NOT NULL,
+                shop_id VARCHAR(48) NOT NULL,
+                shop_name VARCHAR(128) NOT NULL,
+                item_id VARCHAR(48) NOT NULL,
+                item_name VARCHAR(256) NOT NULL,
+                action VARCHAR(4) NOT NULL,
+                amount INT NOT NULL,
+                multiplier DOUBLE NOT NULL,
+                price_text TEXT,
+                message TEXT,
+                INDEX idx_us_transactions_created_at (created_at),
+                INDEX idx_us_transactions_player_uuid (player_uuid)
+            )
+        """;
+    }
+
+    @Override
+    public String insertTransactionLog() {
+        return """
+            INSERT INTO ultimateshop_transactions
+            (created_at, player_uuid, player_name, shop_id, shop_name, item_id, item_name,
+             action, amount, multiplier, price_text, message)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+    }
+
+    @Override
+    public String[] createTransactionLogIndexes() {
+        return new String[0];
+    }
+
+    @Override
     public void needExtraDownload(String jdbcUrl) {
         if (jdbcUrl.startsWith("jdbc:mariadb:")) {
             loadDriver("mariadb-java-client",

--- a/core/src/main/java/cn/superiormc/ultimateshop/database/sql/PostgreSQLDialect.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/database/sql/PostgreSQLDialect.java
@@ -154,6 +154,37 @@ public class PostgreSQLDialect extends DatabaseDialect {
     }
 
     @Override
+    public String createTransactionLogTable() {
+        return """
+            CREATE TABLE IF NOT EXISTS ultimateshop_transactions (
+                id BIGSERIAL PRIMARY KEY,
+                created_at TIMESTAMP NOT NULL,
+                player_uuid VARCHAR(36) NOT NULL,
+                player_name VARCHAR(32) NOT NULL,
+                shop_id VARCHAR(48) NOT NULL,
+                shop_name VARCHAR(128) NOT NULL,
+                item_id VARCHAR(48) NOT NULL,
+                item_name VARCHAR(256) NOT NULL,
+                action VARCHAR(4) NOT NULL,
+                amount INT NOT NULL,
+                multiplier DOUBLE PRECISION NOT NULL,
+                price_text TEXT,
+                message TEXT
+            )
+        """;
+    }
+
+    @Override
+    public String insertTransactionLog() {
+        return """
+            INSERT INTO ultimateshop_transactions
+            (created_at, player_uuid, player_name, shop_id, shop_name, item_id, item_name,
+             action, amount, multiplier, price_text, message)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+    }
+
+    @Override
     public void needExtraDownload(String jdbcUrl) {
         loadDriver("postgresql",
                 "https://repo1.maven.org/maven2/org/postgresql/postgresql/42.6.0/postgresql-42.6.0.jar",

--- a/core/src/main/java/cn/superiormc/ultimateshop/database/sql/PostgreSQLDialect.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/database/sql/PostgreSQLDialect.java
@@ -168,8 +168,7 @@ public class PostgreSQLDialect extends DatabaseDialect {
                 action VARCHAR(4) NOT NULL,
                 amount INT NOT NULL,
                 multiplier DOUBLE PRECISION NOT NULL,
-                price_text TEXT,
-                message TEXT
+                price_text TEXT
             )
         """;
     }
@@ -179,8 +178,8 @@ public class PostgreSQLDialect extends DatabaseDialect {
         return """
             INSERT INTO ultimateshop_transactions
             (created_at, player_uuid, player_name, shop_id, shop_name, item_id, item_name,
-             action, amount, multiplier, price_text, message)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             action, amount, multiplier, price_text)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """;
     }
 

--- a/core/src/main/java/cn/superiormc/ultimateshop/database/sql/SQLiteDialect.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/database/sql/SQLiteDialect.java
@@ -164,6 +164,37 @@ public class SQLiteDialect extends DatabaseDialect {
     }
 
     @Override
+    public String createTransactionLogTable() {
+        return """
+            CREATE TABLE IF NOT EXISTS ultimateshop_transactions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at TEXT NOT NULL,
+                player_uuid TEXT NOT NULL,
+                player_name TEXT NOT NULL,
+                shop_id TEXT NOT NULL,
+                shop_name TEXT NOT NULL,
+                item_id TEXT NOT NULL,
+                item_name TEXT NOT NULL,
+                action TEXT NOT NULL,
+                amount INTEGER NOT NULL,
+                multiplier REAL NOT NULL,
+                price_text TEXT,
+                message TEXT
+            )
+        """;
+    }
+
+    @Override
+    public String insertTransactionLog() {
+        return """
+            INSERT INTO ultimateshop_transactions
+            (created_at, player_uuid, player_name, shop_id, shop_name, item_id, item_name,
+             action, amount, multiplier, price_text, message)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """;
+    }
+
+    @Override
     public void needExtraDownload(String jdbcUrl) {
     }
 }

--- a/core/src/main/java/cn/superiormc/ultimateshop/database/sql/SQLiteDialect.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/database/sql/SQLiteDialect.java
@@ -178,8 +178,7 @@ public class SQLiteDialect extends DatabaseDialect {
                 action TEXT NOT NULL,
                 amount INTEGER NOT NULL,
                 multiplier REAL NOT NULL,
-                price_text TEXT,
-                message TEXT
+                price_text TEXT
             )
         """;
     }
@@ -189,8 +188,8 @@ public class SQLiteDialect extends DatabaseDialect {
         return """
             INSERT INTO ultimateshop_transactions
             (created_at, player_uuid, player_name, shop_id, shop_name, item_id, item_name,
-             action, amount, multiplier, price_text, message)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             action, amount, multiplier, price_text)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """;
     }
 

--- a/core/src/main/java/cn/superiormc/ultimateshop/methods/Product/BuyProductMethod.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/methods/Product/BuyProductMethod.java
@@ -17,8 +17,8 @@ import cn.superiormc.ultimateshop.objects.items.prices.ObjectPrices;
 import cn.superiormc.ultimateshop.objects.buttons.ObjectItem;
 import cn.superiormc.ultimateshop.objects.items.TakeResult;
 import cn.superiormc.ultimateshop.utils.CommonUtil;
-import cn.superiormc.ultimateshop.utils.SchedulerUtil;
 import cn.superiormc.ultimateshop.utils.TextUtil;
+import cn.superiormc.ultimateshop.utils.TransactionLogger;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -244,30 +244,12 @@ public class BuyProductMethod {
                     "amount",
                     String.valueOf(calculateAmount));
         }
-        if (ConfigManager.configManager.getBoolean("log-transaction.enabled") && !UltimateShop.freeVersion) {
-            String log = CommonUtil.modifyString(player, ConfigManager.configManager.getString("log-transaction.format"),
-                    "player", player.getName(),
-                    "player-uuid", player.getUniqueId().toString(),
-                    "shop", item.getShop(),
-                    "shop-name", item.getShopObject().getShopDisplayName(),
-                    "item", item.getProduct(),
-                    "item-name", TextUtil.parse(item.getDisplayName(player)),
-                    "amount", String.valueOf(calculateAmount),
-                    "multiplier", String.valueOf(1.0),
-                    "price", ObjectPrices.getDisplayNameInLine(player,
-                            multi,
-                            takeResult.getResultMap(),
-                            tempVal5.getMode(),
-                            !ConfigManager.configManager.getBoolean("placeholder.status.can-used-everywhere")),
-                    "buy-or-sell", "BUY",
-                    "time", CommonUtil.timeToString(CommonUtil.getNowTime(), ConfigManager.configManager.getString("log-transaction.time-format")));
-            String filePath = ConfigManager.configManager.getString("log-transaction.file");
-            if (filePath.isEmpty()) {
-                TextUtil.sendMessage(null, TextUtil.pluginPrefix() + " §fLog: " + log);
-            } else {
-                SchedulerUtil.runTaskAsynchronously(() -> CommonUtil.logFile(filePath, log));
-            }
-        }
+        TransactionLogger.log(player, item, calculateAmount, String.valueOf(1.0), "BUY",
+                ObjectPrices.getDisplayNameInLine(player,
+                        multi,
+                        takeResult.getResultMap(),
+                        tempVal5.getMode(),
+                        !ConfigManager.configManager.getBoolean("placeholder.status.can-used-everywhere")));
         ItemFinishTransactionEvent event = new ItemFinishTransactionEvent(true, player, multi, item);
         Bukkit.getServer().getPluginManager().callEvent(event);
         return new ProductTradeStatus(ProductTradeStatus.Status.DONE, takeResult, giveResult, multi);

--- a/core/src/main/java/cn/superiormc/ultimateshop/methods/Product/SellProductMethod.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/methods/Product/SellProductMethod.java
@@ -21,8 +21,8 @@ import cn.superiormc.ultimateshop.objects.items.prices.ObjectPrices;
 import cn.superiormc.ultimateshop.objects.items.products.ObjectProducts;
 import cn.superiormc.ultimateshop.utils.CommonUtil;
 import cn.superiormc.ultimateshop.utils.MathUtil;
-import cn.superiormc.ultimateshop.utils.SchedulerUtil;
 import cn.superiormc.ultimateshop.utils.TextUtil;
+import cn.superiormc.ultimateshop.utils.TransactionLogger;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -307,30 +307,12 @@ public class SellProductMethod {
                     "amount",
                     String.valueOf(calculateAmount));
         }
-        if (ConfigManager.configManager.getBoolean("log-transaction.enabled") && !UltimateShop.freeVersion) {
-            String log = CommonUtil.modifyString(player, ConfigManager.configManager.getString("log-transaction.format"),
-                    "player", player.getName(),
-                    "player-uuid", player.getUniqueId().toString(),
-                    "shop", item.getShop(),
-                    "shop-name", item.getShopObject().getShopDisplayName(),
-                    "item", item.getProduct(),
-                    "item-name", TextUtil.parse(item.getDisplayName(player)),
-                    "amount", String.valueOf(calculateAmount),
-                    "multiplier", MathUtil.toDisplayString(finalMultiplier),
-                    "price", ObjectPrices.getDisplayNameInLine(player,
-                            multi,
-                            giveResult.getResultMap(),
-                            item.getSellPrice().getMode(),
-                            !ConfigManager.configManager.getBoolean("placeholder.status.can-used-everywhere")),
-                    "buy-or-sell", "SELL",
-                    "time", CommonUtil.timeToString(CommonUtil.getNowTime(), ConfigManager.configManager.getString("log-transaction.time-format")));
-            String filePath = ConfigManager.configManager.getString("log-transaction.file");
-            if (filePath.isEmpty()) {
-                TextUtil.sendMessage(null, TextUtil.pluginPrefix() + " §fLog: " + log);
-            }  else {
-                SchedulerUtil.runTaskAsynchronously(() -> CommonUtil.logFile(filePath, log));
-            }
-        }
+        TransactionLogger.log(player, item, calculateAmount, MathUtil.toDisplayString(finalMultiplier), "SELL",
+                ObjectPrices.getDisplayNameInLine(player,
+                        multi,
+                        giveResult.getResultMap(),
+                        item.getSellPrice().getMode(),
+                        !ConfigManager.configManager.getBoolean("placeholder.status.can-used-everywhere")));
         ItemFinishTransactionEvent event = new ItemFinishTransactionEvent(false, player, multi, item);
         Bukkit.getServer().getPluginManager().callEvent(event);
         return new ProductTradeStatus(ProductTradeStatus.Status.DONE, takeResult, giveResult, multi);

--- a/core/src/main/java/cn/superiormc/ultimateshop/utils/TransactionLogger.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/utils/TransactionLogger.java
@@ -1,0 +1,111 @@
+package cn.superiormc.ultimateshop.utils;
+
+import cn.superiormc.ultimateshop.UltimateShop;
+import cn.superiormc.ultimateshop.database.SQLDatabase;
+import cn.superiormc.ultimateshop.managers.ConfigManager;
+import cn.superiormc.ultimateshop.managers.DatabaseManager;
+import cn.superiormc.ultimateshop.objects.buttons.ObjectItem;
+import org.bukkit.entity.Player;
+
+public final class TransactionLogger {
+
+    private static boolean databaseMisconfigurationWarned;
+
+    private TransactionLogger() {
+    }
+
+    public static void log(Player player,
+                           ObjectItem item,
+                           int amount,
+                           String multiplier,
+                           String action,
+                           String priceText) {
+        if (!ConfigManager.configManager.getBoolean("log-transaction.enabled") || UltimateShop.freeVersion) {
+            return;
+        }
+
+        String message = CommonUtil.modifyString(player, ConfigManager.configManager.getString("log-transaction.format"),
+                "player", player.getName(),
+                "player-uuid", player.getUniqueId().toString(),
+                "shop", item.getShop(),
+                "shop-name", item.getShopObject().getShopDisplayName(),
+                "item", item.getProduct(),
+                "item-name", TextUtil.parse(item.getDisplayName(player)),
+                "amount", String.valueOf(amount),
+                "multiplier", multiplier,
+                "price", priceText,
+                "buy-or-sell", action,
+                "time", CommonUtil.timeToString(CommonUtil.getNowTime(),
+                        ConfigManager.configManager.getString("log-transaction.time-format")));
+
+        String storage = ConfigManager.configManager.getString("log-transaction.storage");
+        if (storage == null || storage.isBlank()) {
+            storage = "file";
+        }
+        storage = storage.toLowerCase();
+
+        if ("database".equals(storage)) {
+            logToDatabase(player, item, amount, multiplier, action, priceText, message);
+            return;
+        }
+
+        logToFile(message);
+    }
+
+    private static void logToDatabase(Player player,
+                                      ObjectItem item,
+                                      int amount,
+                                      String multiplier,
+                                      String action,
+                                      String priceText,
+                                      String message) {
+        if (!ConfigManager.configManager.getBoolean("database.enabled")) {
+            warnDatabaseMisconfiguration();
+            return;
+        }
+        if (!(DatabaseManager.databaseManager.database instanceof SQLDatabase sqlDatabase)) {
+            warnDatabaseMisconfiguration();
+            return;
+        }
+
+        double multiplierValue;
+        try {
+            multiplierValue = Double.parseDouble(multiplier);
+        } catch (NumberFormatException exception) {
+            multiplierValue = 1.0;
+        }
+
+        sqlDatabase.logTransaction(
+                CommonUtil.getNowTime(),
+                player.getUniqueId().toString(),
+                player.getName(),
+                item.getShop(),
+                item.getShopObject().getShopDisplayName(),
+                item.getProduct(),
+                TextUtil.parse(item.getDisplayName(player)),
+                action,
+                amount,
+                multiplierValue,
+                priceText,
+                message
+        );
+    }
+
+    private static void logToFile(String message) {
+        String filePath = ConfigManager.configManager.getString("log-transaction.file");
+        if (filePath == null || filePath.isEmpty()) {
+            TextUtil.sendMessage(null, TextUtil.pluginPrefix() + " §fLog: " + message);
+            return;
+        }
+        SchedulerUtil.runTaskAsynchronously(() -> CommonUtil.logFile(filePath, message));
+    }
+
+    private static void warnDatabaseMisconfiguration() {
+        if (databaseMisconfigurationWarned) {
+            return;
+        }
+        databaseMisconfigurationWarned = true;
+        TextUtil.sendMessage(null, TextUtil.pluginPrefix()
+                + " §cWarning: log-transaction.storage is database but database.enabled is false or SQL is unavailable. Transaction logs will not be saved.");
+    }
+}

--- a/core/src/main/java/cn/superiormc/ultimateshop/utils/TransactionLogger.java
+++ b/core/src/main/java/cn/superiormc/ultimateshop/utils/TransactionLogger.java
@@ -24,20 +24,6 @@ public final class TransactionLogger {
             return;
         }
 
-        String message = CommonUtil.modifyString(player, ConfigManager.configManager.getString("log-transaction.format"),
-                "player", player.getName(),
-                "player-uuid", player.getUniqueId().toString(),
-                "shop", item.getShop(),
-                "shop-name", item.getShopObject().getShopDisplayName(),
-                "item", item.getProduct(),
-                "item-name", TextUtil.parse(item.getDisplayName(player)),
-                "amount", String.valueOf(amount),
-                "multiplier", multiplier,
-                "price", priceText,
-                "buy-or-sell", action,
-                "time", CommonUtil.timeToString(CommonUtil.getNowTime(),
-                        ConfigManager.configManager.getString("log-transaction.time-format")));
-
         String storage = ConfigManager.configManager.getString("log-transaction.storage");
         if (storage == null || storage.isBlank()) {
             storage = "file";
@@ -45,11 +31,11 @@ public final class TransactionLogger {
         storage = storage.toLowerCase();
 
         if ("database".equals(storage)) {
-            logToDatabase(player, item, amount, multiplier, action, priceText, message);
+            logToDatabase(player, item, amount, multiplier, action, priceText);
             return;
         }
 
-        logToFile(message);
+        logToFile(buildMessage(player, item, amount, multiplier, action, priceText));
     }
 
     private static void logToDatabase(Player player,
@@ -57,8 +43,7 @@ public final class TransactionLogger {
                                       int amount,
                                       String multiplier,
                                       String action,
-                                      String priceText,
-                                      String message) {
+                                      String priceText) {
         if (!ConfigManager.configManager.getBoolean("database.enabled")) {
             warnDatabaseMisconfiguration();
             return;
@@ -86,9 +71,29 @@ public final class TransactionLogger {
                 action,
                 amount,
                 multiplierValue,
-                priceText,
-                message
+                priceText
         );
+    }
+
+    private static String buildMessage(Player player,
+                                       ObjectItem item,
+                                       int amount,
+                                       String multiplier,
+                                       String action,
+                                       String priceText) {
+        return CommonUtil.modifyString(player, ConfigManager.configManager.getString("log-transaction.format"),
+                "player", player.getName(),
+                "player-uuid", player.getUniqueId().toString(),
+                "shop", item.getShop(),
+                "shop-name", item.getShopObject().getShopDisplayName(),
+                "item", item.getProduct(),
+                "item-name", TextUtil.parse(item.getDisplayName(player)),
+                "amount", String.valueOf(amount),
+                "multiplier", multiplier,
+                "price", priceText,
+                "buy-or-sell", action,
+                "time", CommonUtil.timeToString(CommonUtil.getNowTime(),
+                        ConfigManager.configManager.getString("log-transaction.time-format")));
     }
 
     private static void logToFile(String message) {

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -278,7 +278,9 @@ number-display:
 log-transaction:
   # It will cost extra performance cost.
   enabled: false
-  # If set to empty value, we will just print the log into console.
+  # file | database — database requires database.enabled: true
+  storage: file
+  # Used when storage is file. If set to empty value, we will just print the log into console.
   file: 'log.txt'
   format: '{time} | {player} | {shop} | {buy-or-sell} | {item-name} x{amount} | {price} | Price Multiplier: x{multiplier}'
   time-format: "yyyy-MM-dd HH:mm:ss"


### PR DESCRIPTION
## Summary

Adds an optional `log-transaction.storage` setting so successful buy/sell transactions can be written to SQL when `database.enabled` is true, instead of only appending to a flat file.

- `storage: file` (default) — existing behavior unchanged (`log.txt` or console if `file` is empty)
- `storage: database` — inserts structured rows into `ultimateshop_transactions` via the existing Hikari pool and `DatabaseExecutor`

## Motivation

File-based transaction logs are hard to query, aggregate, or integrate with external tools (panels, analytics, audits). 

## Changes

- New `log-transaction.storage` config key (`file` | `database`)
- New `TransactionLogger` helper; deduplicates logging logic from `BuyProductMethod` and `SellProductMethod`
- New `ultimateshop_transactions` table (auto-created on plugin init), with dialect-specific DDL for MySQL/MariaDB, PostgreSQL, H2, and SQLite
- Structured columns: `created_at`, `player_uuid`, `player_name`, `shop_id`, `shop_name`, `item_id`, `item_name`, `action`, `amount`, `multiplier`, `price_text`
- Async inserts on the existing database executor; trade flow is not blocked on log failure

## Config example

log-transaction:
  enabled: true
  storage: database

## Notes

- Premium-only feature (same gate as existing `log-transaction`)
- If `storage: database` is set but `database.enabled` is false, a one-time console warning is shown and logging is skipped
- `format` / `time-format` still apply to file storage only